### PR TITLE
Removed memberpress configuration from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,6 @@ local = [
 # see: https://setuptools.pypa.io/en/latest/userguide/entry_point.html
 #------------------------------------------------------------------------------
 [project.entry-points."lms.djangoapp"]
-memberpress_client = "memberpress_client.apps:MemberPressPluginConfig"
 openedx_plugin = "openedx_plugin.apps:CustomPluginConfig"
 openedx_plugin_api = "openedx_plugin_api.apps:CustomPluginAPIConfig"
 openedx_plugin_mobile_api = "openedx_plugin_mobile_api.apps:MobileApiConfig"


### PR DESCRIPTION
Removed the memberpress configuration which showed module not found while setting up the plugin

```
2023-12-13 05:04:28,634 ERROR 35 [stevedore.extension] [user None] [ip None] extension.py:242 - Could not load 'memberpress_client': No module named 'memberpress_client'
```

I think it is not required!